### PR TITLE
Lexer whitespace and commens tokens.

### DIFF
--- a/JSImpl/src/Lexer.h
+++ b/JSImpl/src/Lexer.h
@@ -88,6 +88,7 @@ enum class TokenType
 	Try,
 	Typeof,
 	Var,
+	Let,
 	Void,
 	While,
 	With,
@@ -98,6 +99,7 @@ enum class TokenType
 	False,
 
 	Whitespace,
+	Comment,
 
 	Eof,
 	Invalid
@@ -120,6 +122,7 @@ struct LexerResult
 struct LexerSettings
 {
 	bool CreateWhitespaceTokens;
+	bool CreateCommentTokens;
 };
 
 LexerResult Tokenize(const char* code, IPLVector<Token>& tokens, const LexerSettings& settings);

--- a/JSImpl/src/Lexer.h
+++ b/JSImpl/src/Lexer.h
@@ -97,6 +97,8 @@ enum class TokenType
 	True,
 	False,
 
+	Whitespace,
+
 	Eof,
 	Invalid
 };
@@ -115,4 +117,9 @@ struct LexerResult
 	IPLError Error;
 };
 
-LexerResult Tokenize(const char* code, IPLVector<Token>& tokens);
+struct LexerSettings
+{
+	bool CreateWhitespaceTokens;
+};
+
+LexerResult Tokenize(const char* code, IPLVector<Token>& tokens, const LexerSettings& settings);

--- a/JSImpl/src/main.cpp
+++ b/JSImpl/src/main.cpp
@@ -11,7 +11,7 @@
 void TestLess()
 {
 	IPLVector<Token> tokens;
-	Tokenize("<", tokens);
+	Tokenize("<", tokens, { false });
 
 	CHECK(tokens.size() == 2 && tokens[0].Type == TokenType::Less);
 }
@@ -19,7 +19,7 @@ void TestLess()
 void TestNumber()
 {
 	IPLVector<Token> tokens;
-	Tokenize("213434.24", tokens);
+	Tokenize("213434.24", tokens, { false });
 
 	CHECK(tokens.size() == 2 && tokens[0].Type == TokenType::Number && tokens[0].Number == 213434.24);
 }
@@ -27,21 +27,21 @@ void TestNumber()
 void TestNumberStartWithNine()
 {
 	IPLVector<Token> tokens;
-	Tokenize("999", tokens);
+	Tokenize("999", tokens, { false });
 	CHECK(tokens.size() == 2 && tokens[0].Type == TokenType::Number && tokens[0].Number == 999);
 }
 
 void TestNumberStartWithZero()
 {
 	IPLVector<Token> tokens;
-	Tokenize("0999", tokens);
+	Tokenize("0999", tokens, { false });
 	CHECK(tokens.size() == 2 && tokens[0].Type == TokenType::Number && tokens[0].Number == 999);
 }
 
 void TestSpaceNewLineSpace()
 {
 	IPLVector<Token> tokens;
-	Tokenize(" \n var a = 4; ", tokens);
+	Tokenize(" \n var a = 4; ", tokens, { false });
 	CHECK(tokens.size() == 6 && tokens[0].Type == TokenType::Var &&
 		tokens[1].Type == TokenType::Identifier &&
 		tokens[2].Type == TokenType::Equal &&
@@ -52,28 +52,28 @@ void TestSpaceNewLineSpace()
 void TestString()
 {
 	IPLVector<Token> tokens;
-	Tokenize("\"alabala\"", tokens);
+	Tokenize("\"alabala\"", tokens, { false });
 	CHECK(tokens.size() == 2 && tokens[0].Type == TokenType::String && tokens[0].Lexeme == "\"alabala\"");
 }
 
 void TestStringSingleQuotedStrings()
 {
 	IPLVector<Token> tokens;
-	Tokenize("'alabala'", tokens);
+	Tokenize("'alabala'", tokens, { false });
 	CHECK(tokens.size() == 2 && tokens[0].Type == TokenType::String && tokens[0].Lexeme == "'alabala'");
 }
 
 void TestKeyWord()
 {
 	IPLVector<Token> tokens;
-	Tokenize("for", tokens);
+	Tokenize("for", tokens, { false });
 	CHECK(tokens.size() == 2 && tokens[0].Type == TokenType::For);
 }
 
 void TestVariableDeclaration()
 {
 	IPLVector<Token> tokens;
-	Tokenize("var pesho = 10", tokens);
+	Tokenize("var pesho = 10", tokens, { false });
 
 	CHECK(tokens.size() == 5 && tokens[0].Type == TokenType::Var
 		&& tokens[1].Type == TokenType::Identifier
@@ -85,16 +85,39 @@ void TestVariableDeclaration()
 void TestStringError()
 {
 	IPLVector<Token> tokens;
-	const auto& res = Tokenize("\"aaaa", tokens);
+	const auto& res = Tokenize("\" aaaa", tokens, { false });
 
-	CHECK(!res.IsSuccessful && res.Error.Row == 0 && res.Error.Column == 5);
+	CHECK(!res.IsSuccessful && res.Error.Row == 0 && res.Error.Column == 6);
+}
+
+void TestWhiteSpaceTokens()
+{
+	IPLVector<Token> tokens;
+	const auto& res = Tokenize(" 1\n2  abc\n \n", tokens, { true });
+	CHECK(res.IsSuccessful
+		&& tokens.size() == 8
+		&& tokens[0].Type == TokenType::Whitespace
+		&& tokens[0].Lexeme == " "
+		&& tokens[1].Type == TokenType::Number
+		&& tokens[1].Number == 1
+		&& tokens[2].Type == TokenType::Whitespace
+		&& tokens[2].Lexeme == "\n"
+		&& tokens[3].Type == TokenType::Number
+		&& tokens[3].Number == 2
+		&& tokens[4].Type == TokenType::Whitespace
+		&& tokens[4].Lexeme == "  "
+		&& tokens[5].Type == TokenType::Identifier
+		&& tokens[5].Lexeme == "abc"
+		&& tokens[6].Type == TokenType::Whitespace
+		&& tokens[6].Lexeme == "\n \n"
+		&& tokens[7].Type == TokenType::Eof);
 }
 
 // Parser Tests
 void TestParseUnaryExpr()
 {
 	IPLVector<Token> tokens;
-	Tokenize("function pesho() { var a = 0; return a; }", tokens);
+	Tokenize("function pesho() { var a = 0; return a; }", tokens, { false });
 
 	// TODO make actual test :D
 	auto expr = Parse(tokens);
@@ -104,17 +127,18 @@ void TestParseUnaryExpr()
 
 int main()
 {
-	//EXECUTE_TEST(TestLess);
-	//EXECUTE_TEST(TestNumber);
-	//EXECUTE_TEST(TestNumberStartWithNine);
-	//EXECUTE_TEST(TestNumberStartWithZero);
-	//EXECUTE_TEST(TestString);
-	//EXECUTE_TEST(TestSpaceNewLineSpace);
-	//EXECUTE_TEST(TestStringSingleQuotedStrings);
-	//EXECUTE_TEST(TestKeyWord);
-	//EXECUTE_TEST(TestVariableDeclaration);
+	EXECUTE_TEST(TestLess);
+	EXECUTE_TEST(TestNumber);
+	EXECUTE_TEST(TestNumberStartWithNine);
+	EXECUTE_TEST(TestNumberStartWithZero);
+	EXECUTE_TEST(TestString);
+	EXECUTE_TEST(TestSpaceNewLineSpace);
+	EXECUTE_TEST(TestStringSingleQuotedStrings);
+	EXECUTE_TEST(TestKeyWord);
+	EXECUTE_TEST(TestVariableDeclaration);
+	EXECUTE_TEST(TestWhiteSpaceTokens);
 
-	TestParseUnaryExpr();
+	// TestParseUnaryExpr();
 #if defined(_WIN32)
 	std::system("pause");
 #endif


### PR DESCRIPTION
# What

>Lexer can now produce whitespace and comment tokens.
>The whitespace and comment tokens are optional and can be turned off or on runtime.
>Added tests.
>Added a lexeme to all one, two or three character tokens like `=`, `==` and `===`.
>Added `let` as a keyword in the lexer.
>Fixed minor errors.

# Who

> 45183

# Check

- Do not commit binary files
- Do not commit generated project files

