### PR TITLE
JSImpl: implement handling of `switch` statements

### DIFF
--- a/JSImpl/src/ASTInterpreter.cpp
+++ b/JSImpl/src/ASTInterpreter.cpp
@@ -1,10 +1,13 @@
 #include "ASTInterpreter.h"
 #include "Expression.h"
 #include <iostream>
+#include <limits>
 #include <math.h>
 
 #undef NOT_IMPLEMENTED
 #define NOT_IMPLEMENTED (void)e; assert(0 && "not-implemented")
+
+#define FLOAT_EQUALS(first, second) fabs(first - second) < std::numeric_limits<double>::epsilon()
 
 struct LValueExtractor : public ExpressionVisitor
 {
@@ -110,7 +113,7 @@ bool ASTInterpreter::EvalIsEqual(const ExpressionPtr& e)
     auto second = m_Evaluation.back();
     m_Evaluation.pop_back();
     auto first = m_Evaluation.back();
-    return fabs(second - first) < 0.0001;
+    return FLOAT_EQUALS(first, second);
 }
 
 void ASTInterpreter::EnterScope()
@@ -215,10 +218,10 @@ void ASTInterpreter::Visit(BinaryExpression* e) {
             m_Evaluation.push_back(right);
             break;
         case TokenType::EqualEqual:
-            m_Evaluation.push_back(fabs(left - right) < 0.0001);
+            m_Evaluation.push_back(FLOAT_EQUALS(left, right));
             break;
         case TokenType::BangEqual:
-            m_Evaluation.push_back(fabs(left - right) > 0.0001);
+            m_Evaluation.push_back(FLOAT_EQUALS(left, right));
             break;
         case TokenType::Equal:
         {

--- a/JSImpl/src/ASTInterpreter.h
+++ b/JSImpl/src/ASTInterpreter.h
@@ -16,6 +16,8 @@ public:
 
     ValueStack Run(Expression* program);
 
+	virtual bool IsInSkipMode() override;
+
     virtual void Visit(LiteralNull* e) override;
     virtual void Visit(LiteralUndefined* e) override;
     virtual void Visit(LiteralString* e) override;

--- a/JSImpl/src/ASTInterpreter.h
+++ b/JSImpl/src/ASTInterpreter.h
@@ -69,4 +69,5 @@ private:
 
     bool m_Fallthrough;
     bool m_Break;
+    bool m_Continue;
 };

--- a/JSImpl/src/ASTInterpreter.h
+++ b/JSImpl/src/ASTInterpreter.h
@@ -52,6 +52,7 @@ public:
 private:
     void RunExpression(const ExpressionPtr& e);
     bool EvalToBool(const ExpressionPtr& e);
+    bool EvalIsEqual(const ExpressionPtr& e);
 
     void EnterScope();
     void LeaveScope();
@@ -63,4 +64,7 @@ private:
 
     typedef IPLVector<IPLString> Scope;
     IPLStack<Scope> m_Scopes;
+
+    bool m_Fallthrough;
+    bool m_Break;
 };

--- a/JSImpl/src/ByteCodeGenerator.cpp
+++ b/JSImpl/src/ByteCodeGenerator.cpp
@@ -111,6 +111,7 @@ private:
 
 	IPLVector<std::pair<size_t, ExpressionPtr>> m_SwitchCases;
 	IPLVector<size_t> m_BreakInstructionAddresses;
+	IPLVector<size_t> m_ContinueInstructionAddresses;
 };
 
 size_t ByteCodeGenerator::PushInstruction(Instruction::Type opcode, const IPLString& arg0, const IPLString& arg1, const IPLString& arg2)
@@ -352,6 +353,10 @@ void ByteCodeGenerator::Visit(ForStatement* e)
 	for (auto breakInstructionAddress : m_BreakInstructionAddresses)
 		m_Code[breakInstructionAddress].Values.Address[0] = m_Code.size();
 	m_BreakInstructionAddresses.clear();
+
+	for (auto continueInstructionAddress : m_ContinueInstructionAddresses)
+		m_Code[continueInstructionAddress].Values.Address[0] = compareAddress;
+	m_ContinueInstructionAddresses.clear();
 }
 
 void ByteCodeGenerator::Visit(SwitchStatement* e)
@@ -445,6 +450,12 @@ void ByteCodeGenerator::Visit(UnaryExpression* e)
 			{
 				auto breakAddress = PushInstruction(Instruction::Type::JMP);
 				m_BreakInstructionAddresses.push_back(breakAddress);
+			}
+			return;
+		case TokenType::Continue:
+			{
+				auto continueAddress = PushInstruction(Instruction::Type::JMP);
+				m_ContinueInstructionAddresses.push_back(continueAddress);
 			}
 			return;
 		default:

--- a/JSImpl/src/Expression.h
+++ b/JSImpl/src/Expression.h
@@ -40,7 +40,7 @@ class Expression : public IPLEnableShared<Expression>
 		:                                                                      \
 		MEMBERS_ITERATOR(EXPAND_INITIALIZER_LIST) m_dummy(__dummy) {}          \
 		virtual ~ClassName() {}                                                \
-		virtual void Accept(ExpressionVisitor& v) override { v.Visit(this); }  \
+		virtual void Accept(ExpressionVisitor& v) override { if (!v.IsInSkipMode()) v.Visit(this); }  \
                                                                                \
 		MEMBERS_ITERATOR(GENERATE_GETTERS)                                     \
 		private:                                                               \

--- a/JSImpl/src/ExpressionVisitor.h
+++ b/JSImpl/src/ExpressionVisitor.h
@@ -7,6 +7,8 @@ class ExpressionVisitor
 public:
 	~ExpressionVisitor() {}
 
+	virtual bool IsInSkipMode() { return false; }
+
 	virtual void Visit(LiteralNull* e) { (void)e; NOT_IMPLEMENTED; }
 	virtual void Visit(LiteralUndefined* e) { (void)e; NOT_IMPLEMENTED; }
 	virtual void Visit(LiteralString* e) { (void)e; NOT_IMPLEMENTED; }


### PR DESCRIPTION
# What

The changes implement handling of `switch` statements in the bytecode generator (as well as the AST interpreter) of the JavaScript implementation.

# Who

Radoslav Georgiev, 81030