### PR TITLE
changed bool Parser::MatchOneOf(IPLVector<TokenType>) argument to be referrence 

### DIFF
--- a/JSImpl/src/Parser.cpp
+++ b/JSImpl/src/Parser.cpp
@@ -6,7 +6,7 @@ public:
 	Parser(const IPLVector<Token>& tokens, const std::function<void()>& onError = {});
 	ExpressionPtr Parse();
 private:
-	bool MatchOneOf(IPLVector<TokenType> types);
+	bool MatchOneOf(const IPLVector<TokenType>& types);
 	bool Match(TokenType type);
 	ExpressionPtr RegularExpression();
 	ExpressionPtr ParenthesizedExpression();
@@ -87,7 +87,7 @@ Parser::Parser(const IPLVector<Token>& tokens, const std::function<void()>& onEr
 {
 }
 
-bool Parser::MatchOneOf(IPLVector<TokenType> types)
+bool Parser::MatchOneOf(const IPLVector<TokenType>& types)
 {
 	for (auto t : types)
 	{


### PR DESCRIPTION
…const with referrence

# What

> bool Parser::MatchOneOf argument was copied and never changed. Therefore I changed the argument to be const with reference

# Angel Dimitroff

> Who you are - 45572

# Check

- Do not commit binary files
- Do not commit generated project files