### PR TITLE
Updated link to theory slides of Garbage Collection presentation

### DIFF
--- a/website/content/slides/10_vm_gc/_index.md
+++ b/website/content/slides/10_vm_gc/_index.md
@@ -18,7 +18,7 @@ outputs: ["Reveal"]
 ---
 ## Theory reminders
 
-1. [Theory](https://www.slideshare.net/eelcovisser/garbage-collection-69688448)
+1. [Theory](https://github.com/TUDelft-IN4303-2016/lectures/raw/master/11-garbage-collection/Garbage%20Collection.pdf)
 0. [Barriers](https://www.cs.kent.ac.uk/pubs/2010/3011/content.pdf)
 0. [Lua GC](http://www.inf.puc-rio.br/~roberto/talks/gc-lua.pdf)
 0. [V8 GC](http://jayconrod.com/posts/55/a-tour-of-v8-garbage-collection)


### PR DESCRIPTION
# What

The link to the "Theory" slides on the Garbage Collection presentation directs to slideshare.net, that website shows ads while presenting and doesn't (easily) allow for download.
I found the [website of the author](https://eelcovisser.org/), the [webpage for the corresponding course](https://tudelft-in4303-2016.github.io/) and subsequently the [PDF version of the presentation](https://github.com/TUDelft-IN4303-2016/lectures/blob/master/11-garbage-collection/Garbage%20Collection.pdf), which is what I've linked.

# Who

Kamen Mladenov - 0MI0800028

# Check

- Do not commit binary files
- Do not commit generated project files

